### PR TITLE
fix: nullable reference types in static reflection tables

### DIFF
--- a/SuperNodes.TestCases/test/test_cases/NullableReferenceTypeMemberTest.cs
+++ b/SuperNodes.TestCases/test/test_cases/NullableReferenceTypeMemberTest.cs
@@ -1,0 +1,17 @@
+namespace NullableReferenceTypeMember;
+
+using Godot;
+using SuperNodes.Types;
+
+[SuperNode(typeof(MyPowerUp))]
+public partial class ExampleNode : Node {
+  public override partial void _Notification(int what);
+}
+
+public class MyObject { }
+
+
+[PowerUp]
+public partial class MyPowerUp : Node {
+  public MyObject? SomeObj { get; set; }
+}

--- a/SuperNodes.Tests/tests/common/services/CodeServiceTest.cs
+++ b/SuperNodes.Tests/tests/common/services/CodeServiceTest.cs
@@ -217,6 +217,8 @@ public class BasicSyntaxOperationsServiceTest {
 
         protected readonly int _field2 = 1;
 
+        public string? NullableProperty { get; set;  }
+
         public void Method() {}
       }
 
@@ -304,6 +306,19 @@ public class BasicSyntaxOperationsServiceTest {
           )
         ),
         new PropOrField(
+          Name: "NullableProperty",
+          Reference: "NullableProperty",
+          Type: "string",
+          Attributes: ImmutableArray<AttributeDescription>.Empty,
+          IsField: false,
+          IsMutable: true,
+          IsReadable: true,
+          NameParts: ImmutableArray<SimpleSymbolDisplayPart>.Empty,
+          TypeParts: ImmutableArray.Create(
+            new SimpleSymbolDisplayPart(SymbolDisplayPartKind.Keyword, "string")
+          )
+        ),
+        new PropOrField(
           Name: "Property",
           Reference: "Property",
           Type: "string",
@@ -323,7 +338,7 @@ public class BasicSyntaxOperationsServiceTest {
           TypeParts: ImmutableArray.Create(
             new SimpleSymbolDisplayPart(SymbolDisplayPartKind.Keyword, "string")
           )
-        ),
+        )
        }.ToImmutableArray();
 
     result.ShouldDeepEqual(expected);

--- a/SuperNodes.Types/Chickensoft.SuperNodes.Types.csproj
+++ b/SuperNodes.Types/Chickensoft.SuperNodes.Types.csproj
@@ -11,7 +11,7 @@
     <DebugType>portable</DebugType>
 
     <Title>SuperNodes Types</Title>
-    <Version>1.6.0</Version>
+    <Version>1.6.1</Version>
     <Description>Runtime types for SuperNodes.</Description>
     <Copyright>© 2023 Chickensoft</Copyright>
     <Authors>Chickensoft</Authors>

--- a/SuperNodes/Chickensoft.SuperNodes.csproj
+++ b/SuperNodes/Chickensoft.SuperNodes.csproj
@@ -13,7 +13,7 @@
     <NoWarn>NU5128</NoWarn>
 
     <Title>SuperNodes</Title>
-    <Version>1.6.0</Version>
+    <Version>1.6.1</Version>
     <Description>Supercharge your Godot nodes with lifecycle-aware mixins, third party source generators, script introspection, and dynamic property manipulation — all without runtime reflection!</Description>
     <Copyright>© 2023 Chickensoft Games</Copyright>
     <Authors>Chickensoft</Authors>

--- a/SuperNodes/src/common/services/CodeService.cs
+++ b/SuperNodes/src/common/services/CodeService.cs
@@ -363,6 +363,12 @@ public class CodeService : ICodeService {
         isMutable = !field.IsReadOnly;
       }
 
+      // Remove any trailing ? part from typeParts — we don't need to worry
+      // about overall nullability.
+      if (typeParts.Length > 0 && typeParts.Last().Value == "?") {
+        typeParts = typeParts.RemoveAt(typeParts.Length - 1);
+      }
+
       var attributes = GetAttributesForPropOrField(rawAttributes);
 
       var propOrField = new PropOrField(


### PR DESCRIPTION
- prevents nullable reference types from breaking static reflection table generation: i.e., optional properties and fields that are added to a node from a PowerUp won't break supernode  generation.