### PR TITLE
Strip where clauses from the PowerUp code.

### DIFF
--- a/SuperNodes.TestCases/test/test_cases/GenericWithWhereClause.cs
+++ b/SuperNodes.TestCases/test/test_cases/GenericWithWhereClause.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Godot;
+using SuperNodes.Types;
+
+public class MyDisposable : IDisposable {
+  public void Dispose() { }
+}
+
+[SuperNode(typeof(GenericWithWhereClause<MyDisposable>))]
+public partial class TestNode : Node {
+  public override partial void _Notification(int what);
+}
+
+[PowerUp]
+public class GenericWithWhereClause<T> where T : IDisposable {
+  public void OnMyPowerUp(int what) { }
+}
+
+//we only need to make sure that this code compiles, no runtime check is required.

--- a/SuperNodes/src/PowerUpsFeature/PowerUpGenerator.cs
+++ b/SuperNodes/src/PowerUpsFeature/PowerUpGenerator.cs
@@ -61,6 +61,8 @@ public class PowerUpGenerator : ChickensoftGenerator, IPowerUpGenerator {
         )
       )
     )
+    // Strip where clauses
+    .WithConstraintClauses(new SyntaxList<TypeParameterConstraintClauseSyntax>())
     // Change power up name to the node's name.
     .WithIdentifier(SyntaxFactory.Identifier(node.Name))
     .WithTypeParameterList(null)


### PR DESCRIPTION
Hi there, thank you for your great library, with it I can finally get my DI framework up and running. 

While playing with SuperNode, I found a bug in it, with the following code:

````
public class MyDisposable : IDisposable {
  public void Dispose() { }
}

[SuperNode(typeof(GenericWithWhereClause<MyDisposable>))]
public partial class TestNode : Node {
  public override partial void _Notification(int what);
}

[PowerUp]
public class GenericWithWhereClause<T> where T : IDisposable {
  public void OnMyPowerUp(int what) { }
}

````
The generated code will become: 
````
#pragma warning disable
#nullable enable
using System;
using Godot;
using SuperNodes.Types;
  partial class TestNode where global::MyDisposable : IDisposable
  {
    public void OnMyPowerUp(int what)
    {
    }
  }
#nullable disable
#pragma warning restore
````
Which is definitely not legal C# code.

This PR fix this bug by strip the where clauses from the PowerUp code.

Removing the where clauses in the PowerUp code should not be a problem as the generic parameters of PowerUp are replaced with real type during code generation... am I right?

This is my first time playing with C#'s codegen technology, mistakes may be made, feel free to leave any comments, or you can reject this if you decide to fix this by yourself.